### PR TITLE
Update svf-utils.c

### DIFF
--- a/utils/svf-utils.c
+++ b/utils/svf-utils.c
@@ -800,7 +800,12 @@ void svf_cache_remove(svf_cache_handle *cache_h, svf_cache_entry *cache_e)
 	DEBUG(10,("Purging cache entry: %s\n", cache_e->fname));
 
 	if (cache_h->end == cache_e) {
-		cache_h->end = cache_e->prev;
+                if (cache_e = cache_e-> prev) {
+                        // its the last entry in the list
+                        cache_h->end = NULL;
+                } else {
+                        cache_h->end = cache_e->prev;
+                }
 	}
 	cache_h->entry_num--;
 	DLIST_REMOVE(cache_h->list, cache_e);


### PR DESCRIPTION
We experience a problem with scan on close = yes (and scan on open = no) where the samba process is terminated and coredump produced. This seems to happen only on slower network connections when saving microsoft office documents.
On investigation it looks like an access after free error when accessing the cache and this is caused when the last entry of the cache is deleted (and freed) and the *end pointer is set to the *prev pointer of the entry about to be deleted. In samba 3.6 the *prev pointer points the itself for the last entry (see DLIST_ADD) which means that *end is set to an entry which has been removed and freed.
This fix seems to fix it and so does disabling the cache (svf-clamav:cache entry limit = -1).
I'm still not entirely sure why it only happens on slow connections?

I'm not really sure why you would want to use the cache when just using scan on close - seems like it should never get used.
