### PR TITLE
Include patch needed for properly using Samba memcache, if ever merged upstream.

### DIFF
--- a/contrib/SVF_SCAN_RESULTS_CACHE_TALLOC.patch
+++ b/contrib/SVF_SCAN_RESULTS_CACHE_TALLOC.patch
@@ -1,0 +1,27 @@
+diff --git a/lib/util/memcache.c b/lib/util/memcache.c
+index 9e9a208..f93c898 100644
+--- a/lib/util/memcache.c
++++ b/lib/util/memcache.c
+@@ -53,6 +53,7 @@ static bool memcache_is_talloc(enum memcache_number n)
+        case GETPWNAM_CACHE:
+        case PDB_GETPWSID_CACHE:
+        case SINGLETON_CACHE_TALLOC:
+        case SHARE_MODE_LOCK_CACHE:
++       case SVF_SCAN_RESULTS_CACHE_TALLOC:
+                result = true;
+                break;
+diff --git a/lib/util/memcache.h b/lib/util/memcache.h
+index 2602fb7..a80d36e 100644
+--- a/lib/util/memcache.h
++++ b/lib/util/memcache.h
+@@ -41,7 +41,8 @@ enum memcache_number {
+        SINGLETON_CACHE_TALLOC, /* talloc */
+        SINGLETON_CACHE,
+        SMB1_SEARCH_OFFSET_MAP,
+-       SHARE_MODE_LOCK_CACHE   /* talloc */
++       SHARE_MODE_LOCK_CACHE,  /* talloc */
++       SVF_SCAN_RESULTS_CACHE_TALLOC /* talloc */
+ };
+ 
+ /*
+

--- a/include/svf-utils.h
+++ b/include/svf-utils.h
@@ -33,6 +33,7 @@
 #define SVF_IO_BUFFER_SIZE	(SVF_IO_URL_MAX + 128)
 #define SVF_IO_EOL_SIZE		2
 #define SVF_IO_IOV_MAX		16
+#define SVF_CACHE_BUFFER_SIZE	(PATH_MAX + 128)
 
 typedef struct svf_io_handle {
 	int		socket;

--- a/utils/svf-utils.c
+++ b/utils/svf-utils.c
@@ -696,7 +696,7 @@ svf_cache_handle *svf_cache_new(TALLOC_CTX *ctx, int entry_limit, time_t time_li
 		return NULL;
 	}
 
-	cache_h->cache = memcache_init(cache_h->ctx, entry_limit * (sizeof(svf_cache_entry) + 128));
+	cache_h->cache = memcache_init(cache_h->ctx, entry_limit * (sizeof(svf_cache_entry) + SVF_CACHE_BUFFER_SIZE));
 	if (!cache_h->cache) {
 		DEBUG(0,("memcache_init failed.\n"));
 		return NULL;


### PR DESCRIPTION
Better estimate memory usage for memcache. User: if too much memory is used, lower the number of files to cache results for. After all, that number is now just an estimate.